### PR TITLE
Making the validation of identifier names match the spec and docs (fixes #25)

### DIFF
--- a/lib/utils/main.js
+++ b/lib/utils/main.js
@@ -445,7 +445,7 @@ util.assertOptions = function(options, allowedKeys, query) {
 }
 
 util.assertNoSpecialChar = function assertNoSpecialChar(value, type, query) {
-  if (!value.match(/^[0-9a-zA-Z]+$/)) {
+  if (!value.match(/^[A-Za-z0-9_]+$/)) {
     throw new Error.ReqlRuntimeError(type+" name `"+value+"` invalid (Use A-Za-z0-9_ only)", query.frames)
   }
 }
@@ -667,7 +667,7 @@ util.validDate = function(date) {
 //TODO CamelCase the thing
 util.dateToString = function(date) {
   var timezone = date.timezone;
-  
+
   // Extract data from the timezone
   var timezone_array = date.timezone.split(':');
   var sign = timezone_array[0][0]; // Keep the sign


### PR DESCRIPTION
Underscores weren't being allowed when the should have been.
https://github.com/neumino/reqlite/issues/25

Test:

```
nesh*> yield r.dbCreate('al_stewart')
{ config_changes: [ { new_val: [Object], old_val: null } ],
  dbs_created: 1 }
nesh*> yield r.dbList()
[ 'al_stewart' ]
```