### PR TITLE
Additional options to `r.http`

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -3787,12 +3787,8 @@ Query.prototype.http = function(args, options, internalOptions) {
         encoding: null,
         timeout: internalOptions.timeout || 30000,
         maxRedirects: internalOptions.redirects || 1,
-        headers: {
-          "Accept": "*/*" ,
-          "Accept-Encoding": "deflate;q=1, gzip;q=0.5" ,
-          // "Host": "httpbin.org" ,
-          "User-Agent": "RethinkDB/2.0.2"
-        }
+        qs: internalOptions.params,
+        headers: httpUtil.headers(internalOptions.header)
       };
       request.get(options, function(err, httpResponse, body) {
         if (err) {

--- a/lib/query.js
+++ b/lib/query.js
@@ -3,6 +3,7 @@
 var protodef = require(__dirname+"/protodef.js");
 var termTypes = protodef.Term.TermType;
 var util = require(__dirname+"/utils/main.js");
+var httpUtil = require(__dirname+"/utils/http.js");
 var Promise = require("bluebird");
 var request = require('request');
 
@@ -799,7 +800,7 @@ Query.prototype.getAll = function(args, options, internalOptions) {
   }).then(function(table) {
     util.assertType(table, 'TABLE', self);
     self.frames.pop();
-    this.table = table;  
+    this.table = table;
     return Promise.map(args.slice(1), function(arg, index) {
       self.frames.push(index+1)
       return self.evaluate(arg, internalOptions).then(function(result) {
@@ -1395,7 +1396,7 @@ Query.prototype.object = function(args, options, internalOptions) {
           throw new Error.ReqlRuntimeError('Duplicate key `'+key+'` in object.  (got `'+JSON.stringify(result[key], null, 4)+'` and `'+JSON.stringify(value, null, 4)+'` as values)', self.frames)
         }
         result[key] = value;
-        key = undefined; 
+        key = undefined;
       }
       return result
     });
@@ -2384,7 +2385,7 @@ Query.prototype.indexCreate = function(args, options, internalOptions) {
     util.assertType(table, 'TABLE', self);
     self.frames.pop();
     this.table = table;
-    return self.evaluate(args[1], internalOptions); 
+    return self.evaluate(args[1], internalOptions);
   }).then(function(name) {
     util.assertType(name, 'STRING', self);
     return this.table.indexCreate(name, args[2], options, self);
@@ -2476,7 +2477,7 @@ Query.prototype.indexWait = Query.prototype.indexStatus;
 Query.prototype.funcall = function(args, options, internalOptions) {
   var self = this;
   // FUNCALL, FN [ AR[], BODY]
-  //  0       1  [ 0 [ ...], 
+  //  0       1  [ 0 [ ...],
   util.assertArityRange(1, Infinity, args, this);
   if (args.length === 1) {
     return self.evaluate(args[0], internalOptions);
@@ -3783,6 +3784,8 @@ Query.prototype.http = function(args, options, internalOptions) {
     return new Promise(function(resolve, reject) {
       var options = {
         url: url,
+        timeout: internalOptions.timeout || 30000,
+        maxRedirects: internalOptions.redirects || 1,
         headers: {
           "Accept": "*/*" ,
           "Accept-Encoding": "deflate;q=1, gzip;q=0.5" ,
@@ -3795,12 +3798,24 @@ Query.prototype.http = function(args, options, internalOptions) {
           reject(err);
         }
         else {
-          //TODO Handle more options
           var response = body;
-          if (httpResponse.headers['content-type'] === 'application/json') {
-            response = JSON.parse(response);
+          var format = httpUtil.responseFormat(internalOptions.resultFormat, httpResponse.headers['content-type']);
+          switch (format) {
+            case 'json':
+              response = JSON.parse(response);
+              break;
+            case 'jsonp':
+              response = response.slice(response.indexOf('{'), response.lastIndexOf('}'));
+              response = JSON.parse(response);
+              break;
+            case 'binary':
+              response = {
+                $reql_type$: 'BINARY',
+                data: new Buffer(response)
+              };
+              break;
           }
-          resolve(response);
+          return resolve(response);
         }
       });
     });

--- a/lib/query.js
+++ b/lib/query.js
@@ -3784,12 +3784,13 @@ Query.prototype.http = function(args, options, internalOptions) {
     return new Promise(function(resolve, reject) {
       var options = {
         url: url,
+        encoding: null,
         timeout: internalOptions.timeout || 30000,
         maxRedirects: internalOptions.redirects || 1,
         headers: {
           "Accept": "*/*" ,
           "Accept-Encoding": "deflate;q=1, gzip;q=0.5" ,
-          "Host": "httpbin.org" ,
+          // "Host": "httpbin.org" ,
           "User-Agent": "RethinkDB/2.0.2"
         }
       };
@@ -3798,7 +3799,7 @@ Query.prototype.http = function(args, options, internalOptions) {
           reject(err);
         }
         else {
-          var response = body;
+          var response = body.toString('utf8');
           var format = httpUtil.responseFormat(internalOptions.resultFormat, httpResponse.headers['content-type']);
           switch (format) {
             case 'json':
@@ -3811,7 +3812,7 @@ Query.prototype.http = function(args, options, internalOptions) {
             case 'binary':
               response = {
                 $reql_type$: 'BINARY',
-                data: new Buffer(response)
+                data: body.toString('base64')
               };
               break;
           }

--- a/lib/utils/http.js
+++ b/lib/utils/http.js
@@ -28,3 +28,24 @@ httpUtil.responseFormat = function (requestedFormat, contentType) {
 
   return requestedFormat;
 }
+
+httpUtil.headers = function (headers) {
+  if (headers === undefined) {
+    headers = {};
+  }
+  // handle array of strings
+  else if (Array.isArray(headers)) {
+    headers = headers.reduce(function (prev, val) {
+      var parts = val.split(/:\s*/);
+      prev[parts[0]] = parts[1];
+      return prev;
+    });
+  }
+
+  // defaults
+  headers['Accept'] = headers['Accept'] || '*/*';
+  headers['Accept-Encoding'] = headers['Accept-Encoding'] || 'deflate;q=1, gzip;q=0.5';
+  headers['User-Agent'] = headers['User-Agent'] || 'RethinkDB/2.0.2'; // TODO: read version from package.json
+
+  return headers;
+}

--- a/lib/utils/http.js
+++ b/lib/utils/http.js
@@ -1,0 +1,30 @@
+var httpUtil = module.exports;
+
+httpUtil.responseFormat = function (requestedFormat, contentType) {
+  contentType = contentType.split(';')[0];
+
+  if (requestedFormat === undefined || requestedFormat === 'auto') {
+    switch (contentType) {
+      case 'application/json':
+        return 'json';
+      case 'application/json-p':
+      case 'text/json-p':
+      case 'text/javascript':
+        return 'jsonp';
+      case 'application/octet-stream':
+        return 'binary';
+      default:
+        var topLevel = contentType.split('/')[0];
+        switch (topLevel) {
+          case 'audio':
+          case 'video':
+          case 'image':
+            return 'binary';
+          default:
+            return 'text';
+        }
+    }
+  }
+
+  return requestedFormat;
+}

--- a/test/control-structures.js
+++ b/test/control-structures.js
@@ -1258,6 +1258,11 @@ describe('control-structures.js', function(){
     compare(query, done);
   })
 
+  it('http - params', function(done) {
+    var query = r.http('http://httpbin.org/get', { params: { foo: 'bar' } });
+    compare(query, done);
+  })
+
   /*
   it('range - 5', function(done) { // less than one batch
     var query = r.range();

--- a/test/control-structures.js
+++ b/test/control-structures.js
@@ -1245,11 +1245,7 @@ describe('control-structures.js', function(){
 
   it('http - 3', function(done) {
     var query = r.http('http://httpbin.org/image/png', { resultFormat: 'binary' });
-    compare(query, done, function(result) {
-      // The distribution may be added in the user agent (like on Travis)
-      console.log('result', result);
-      return result;
-    });
+    compare(query, done);
   })
 
   /*

--- a/test/control-structures.js
+++ b/test/control-structures.js
@@ -1243,8 +1243,18 @@ describe('control-structures.js', function(){
     });
   })
 
-  it('http - 3', function(done) {
+  it('http - binary', function(done) {
     var query = r.http('http://httpbin.org/image/png', { resultFormat: 'binary' });
+    compare(query, done);
+  })
+
+  it('http - header - 1', function(done) {
+    var query = r.http('http://httpbin.org/get', { header: { 'User-Agent': 'NotDefault/1.0' } });
+    compare(query, done);
+  })
+
+  it('http - header - 2', function(done) {
+    var query = r.http('http://httpbin.org/get', { header: [ 'User-Agent: NotDefault/1.0' ] });
     compare(query, done);
   })
 

--- a/test/control-structures.js
+++ b/test/control-structures.js
@@ -162,7 +162,7 @@ describe('control-structures.js', function(){
     var query = r.binary(new Buffer('a')).count();
     compare(query, done);
   });
-  
+
   it('do - 1', function(done) {
     var query = r.expr('hello').do(function(value) {
       return value.add('bar');
@@ -1239,6 +1239,15 @@ describe('control-structures.js', function(){
     compare(query, done, function(result) {
       // The distribution may be added in the user agent (like on Travis)
       delete result[3].headers["User-Agent"]
+      return result;
+    });
+  })
+
+  it('http - 3', function(done) {
+    var query = r.http('http://httpbin.org/image/png', { resultFormat: 'binary' });
+    compare(query, done, function(result) {
+      // The distribution may be added in the user agent (like on Travis)
+      console.log('result', result);
       return result;
     });
   })


### PR DESCRIPTION
Still not the complete list, but this adds support for:

- resultFormat
- timeout (needs test)
- redirects (needs test)
- header
- params

There are currently three failing test cases. I think this is because `Query::evaluate` is stripping out all the options passed to `r.http`. I haven't had time to figure out why that's the case and I'm also not sure whether I should expect `options` or `internalOptions` to be populated with the user-supplied options. Let me know and I'll update this PR.

The reason I don't have tests for `timeout` and `redirects` is because (AFAIK) there's no way to do that with httpbin.