### PR TITLE
Update deepcopy to handle nested documents

### DIFF
--- a/lib/utils/main.js
+++ b/lib/utils/main.js
@@ -748,7 +748,11 @@ util.deepCopy = function(value) {
     return result;
   }
   else if (util.isPlainObject(value)) {
-    result = {};
+    if (util.isDocument(value)){
+      result = new Document();
+    } else {
+      result = {};
+    }
     var keys = Object.keys(value);
     for(var i=0; i<keys.length; i++) {
       result[keys[i]] = util.deepCopy(value[keys[i]]);

--- a/test/document-manipulation.js
+++ b/test/document-manipulation.js
@@ -451,6 +451,18 @@ describe('document-manipulation.js', function(){
     }).pluck({foo: {bar : true}}, 'foo');
     compare(query, done);
   });
+  
+  it('without - 38', function(done) {
+    var mergedoc = r.db(TEST_DB).table(TEST_TABLE).get(1);
+    var query = r.expr(COMPLEX_OBJECT).merge({"baz": mergedoc}).without("buzz");
+    compare(query, done);
+  });
+  
+  it('without - 39', function(done) {
+    var mergedoc = r.db(TEST_DB).table(TEST_TABLE).get(1);
+    var query = r.expr(COMPLEX_OBJECT).without("buzz").merge({"baz": mergedoc});
+    compare(query, done);
+  });
 
   it('merge - 1', function(done) {
     var query = r.expr({foo: 'bar'}).merge({foo: 'lol'})
@@ -540,7 +552,7 @@ describe('document-manipulation.js', function(){
   });
 
   it('merge - 18', function(done) {
-    var query = r.expr({foo: 2}).merge({foo: r.row('foo').mul(r.row('foo'))}, {foo: r.row('foo').mul(r.row('foo'))}) 
+    var query = r.expr({foo: 2}).merge({foo: r.row('foo').mul(r.row('foo'))}, {foo: r.row('foo').mul(r.row('foo'))})
     compare(query, done);
   });
 


### PR DESCRIPTION
In queries that include nested documents, deepcopy wasn't
capturing that the nested documents were documents,
which is sometimes tested using isinstance. This ensures
that the type is retained through deep copies.

This adds two tests, as well. "without - 38" failed prior to
this patch. "without - 39" succeeded, but was included to
test that the order of the merge() and without() methods was
signficant in triggering the deepcopy issue.