### PR TITLE
When merging docs, just merge values

### DIFF
--- a/lib/utils/main.js
+++ b/lib/utils/main.js
@@ -532,6 +532,9 @@ util.mergeDatum = function merge(self, obj) {
     else if (util.isPlainObject(obj[key]) && util.isPlainObject(result[key])) {
       result[key] = util.mergeDatum(result[key], obj[key]);
     }
+    else if (util.isDocument(obj[key])) {
+      result[key] = obj[key].doc;
+    }
     else {
       result[key] = obj[key];
     }

--- a/test/document-manipulation.js
+++ b/test/document-manipulation.js
@@ -451,6 +451,18 @@ describe('document-manipulation.js', function(){
     }).pluck({foo: {bar : true}}, 'foo');
     compare(query, done);
   });
+  
+  it('without - 38', function(done) {
+    var mergedoc = r.db(TEST_DB).table(TEST_TABLE).get(1);
+    var query = r.expr(COMPLEX_OBJECT).merge({"baz": mergedoc}).without("buzz");
+    compare(query, done);
+  });
+  
+  it('without - 39', function(done) {
+    var mergedoc = r.db(TEST_DB).table(TEST_TABLE).get(1);
+    var query = r.expr(COMPLEX_OBJECT).without("buzz").merge({"baz": mergedoc});
+    compare(query, done);
+  });
 
   it('merge - 1', function(done) {
     var query = r.expr({foo: 'bar'}).merge({foo: 'lol'})


### PR DESCRIPTION
Per neumino's comment on my [deepcopy pull request](https://github.com/neumino/reqlite/pull/46), merge should only copy the value of a document, not the full context of the document.