### PR TITLE
replace request with superagent

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -4,7 +4,7 @@ var protodef = require("./protodef.js");
 var termTypes = protodef.Term.TermType;
 var util = require("./utils/main.js");
 var Promise = require("bluebird");
-var request = require('request');
+var request = require('superagent');
 
 var Database = require("./database.js");
 var Group = require("./group.js");
@@ -3811,26 +3811,17 @@ Query.prototype.http = function(args, options, internalOptions) {
   return self.evaluate(args[0], internalOptions).then(function(url) {
     self.frames.pop();
     return new Promise(function(resolve, reject) {
-      var options = {
-        url: url,
-        headers: {
-          "Accept": "*/*" ,
-          "Accept-Encoding": "deflate;q=1, gzip;q=0.5" ,
-          "Host": "httpbin.org" ,
-          "User-Agent": "RethinkDB/2.0.2"
-        }
-      };
-      request.get(options, function(err, httpResponse, body) {
-        if (err) {
+      request.get(url).set({
+        "Accept": "*/*" ,
+        "Accept-Encoding": "deflate;q=1, gzip;q=0.5" ,
+        "Host": "httpbin.org" ,
+        "User-Agent": "RethinkDB/2.0.2"
+      }).end(function(err, res){
+        if(err){
           reject(err);
         }
-        else {
-          //TODO Handle more options
-          var response = body;
-          if (httpResponse.headers['content-type'] === 'application/json') {
-            response = JSON.parse(response);
-          }
-          resolve(response);
+        else{
+          resolve(res.body || res.text);
         }
       });
     });

--- a/lib/utils/main.js
+++ b/lib/utils/main.js
@@ -10,26 +10,26 @@ util.log = function() {
 
 module.exports = util;
 
-var Error = require(__dirname+"/../error.js");
-var Minval = require(__dirname+"/../minval.js");
-var Maxval = require(__dirname+"/../maxval.js");
-var Asc = require(__dirname+"/../asc.js");
-var Desc = require(__dirname+"/../desc.js");
-var Literal = require(__dirname+"/../literal.js");
-var ReqlGeometry = require(__dirname+"/../geo.js");
-var ReqlDate = require(__dirname+"/../date.js");
-var protodef = require(__dirname+"/../protodef.js");
+var Error = require("../error.js");
+var Minval = require("../minval.js");
+var Maxval = require("../maxval.js");
+var Asc = require("../asc.js");
+var Desc = require("../desc.js");
+var Literal = require("../literal.js");
+var ReqlGeometry = require("../geo.js");
+var ReqlDate = require("../date.js");
+var protodef = require("../protodef.js");
 var GeographicLib = require("geographiclib");
 var termTypes = protodef.Term.TermType;
 // Lazily loaded
 // TODO Fix the dependencies
-var Sequence = require("./../sequence.js");
-var Database = require("./../database.js");
-var Table = require("./../table.js");
-var Document = require("./../document.js");
-var MissingDoc = require("./../missing_doc.js");
-var Changes = require("./../changes.js");
-var Group = require("./../group.js");
+var Sequence = require("../sequence.js");
+var Database = require("../database.js");
+var Table = require("../table.js");
+var Document = require("../document.js");
+var MissingDoc = require("../missing_doc.js");
+var Changes = require("../changes.js");
+var Group = require("../group.js");
 var Promise = require("bluebird");
 
 


### PR DESCRIPTION
This PR is to replace usage of `request` with `superagent` - https://github.com/visionmedia/superagent. This is built for so-called 'isomorphic' stack; specifically it's much lighter by weight on the browser, and doesn't bundle along a number of node-specific bits. I've used this at scale in many big projects, and it works well. 