### PR TITLE
Fix issue with UUID in query

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -612,7 +612,7 @@ Query.prototype.evaluate = function(term, internalOptions) {
       // Throws
       return util.notAvailable(null, this);
     default:
-      throw new Ereor.ReqlRuntimeError("Unknown term", this.frames);
+      throw new Error.ReqlRuntimeError("Unknown term", this.frames);
   }
 };
 
@@ -675,7 +675,7 @@ Query.prototype.javascript = function(args, options, internalOptions) {
 
 Query.prototype.uuid = function(args, options, internalOptions) {
   util.assertArityRange(0, 1, args, this);
-  if (args.length === 1) {
+  if (args && args.length === 1) {
     return this.evaluate(args[0], internalOptions).then(function(name) {
       return util.uuidV5(constants.UUID_NAMESPACE, name);
     });


### PR DESCRIPTION
When using `r.uuid()` as a default in a `thinky` model, the `args` variable is `undefined`. This used to crash, but is fixed in this MR.

I hope you can still consider merging and releasing this, even though the project seems to be unmaintained for a while now.